### PR TITLE
Refactor `HashNode` / `HashTree`: delegate some `Option` handles and limit recursive calls

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -2,7 +2,7 @@ name: Rust
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [ '*' ]
   pull_request:
     branches: [ "master" ]
 

--- a/README.md
+++ b/README.md
@@ -66,10 +66,10 @@ The crates in this workspace may rely on other renowned, widely tried and tested
 
 ## Improvements
 - Make the most of the prior knowledge of a Merkle tree partitioning:
-  - Limit recursive calls when computing the depth and the length of a tree, eg. using const generic parameters to statically store the depth of a node.
+  - ~~Limit recursive calls when computing the depth and the length of a tree, eg. using const generic parameters to statically store the depth of a node~~.
   - Specialize node iterators, potentially implementing additional `ExactSizeIterator` and `DoubleEndedIterator` traits.
 - Make `HashProof` compliant with ownership unconstrained to `HashTree`'s lifetime (turning it into owned values when required), eg. using `Cow`.
-- Try to reduce `Option` and `Option::unwrap()` usage in `HashNode` handling.
+- ~~Try to reduce `Option` and `Option::unwrap()` usage in `HashNode` handling~~.
 - Implement `serde` (de)serialization traits for `HashTree`, `HashNode` and `HashProof` types.
 - Make a whole hash tree fully compliant and optimized for concurrent access, locking only the part of the subtree actually requiring to be updated, eg. using `RwLock`.
 

--- a/hashtree/src/hash/context.rs
+++ b/hashtree/src/hash/context.rs
@@ -1,13 +1,38 @@
 use std::cmp::Ordering;
 
+use super::{HashNode, Hasher};
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(super) struct Depth(u8, Option<u8>);
 
 impl Depth {
     #[inline]
-    pub(super) fn new(min: u8, max: u8) -> Self {
+    fn new(min: u8, max: u8) -> Self {
         debug_assert!(min <= max);
         Self(max, (min < max).then_some(min))
+    }
+
+    #[inline]
+    fn merge(left: Self, right: Self) -> Self {
+        Self::new(
+            u8::min(left.1.unwrap_or(left.0), right.1.unwrap_or(right.0)),
+            u8::max(left.0, right.0),
+        )
+    }
+
+    #[inline]
+    fn bump(self) -> Self {
+        Self(self.0 + 1, self.1.map(|min| min + 1))
+    }
+
+    #[inline]
+    pub fn min(&self) -> Option<u8> {
+        self.1
+    }
+
+    #[inline]
+    pub fn max(&self) -> u8 {
+        self.0
     }
 }
 
@@ -41,5 +66,28 @@ impl From<Depth> for (u8, Option<u8>) {
     #[inline]
     fn from(depth: Depth) -> Self {
         (depth.0, depth.1)
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct Context(usize, Depth);
+
+impl Context {
+    #[inline]
+    pub fn depth(&self) -> Depth {
+        self.1
+    }
+
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.0
+    }
+}
+
+impl<H: Hasher> From<(&HashNode<H>, &HashNode<H>)> for Context {
+    fn from((left, right): (&HashNode<H>, &HashNode<H>)) -> Self {
+        let depth = Depth::merge(left.depth(), right.depth());
+
+        Self(left.len() + right.len(), depth.bump())
     }
 }

--- a/hashtree/src/hash/context.rs
+++ b/hashtree/src/hash/context.rs
@@ -1,0 +1,45 @@
+use std::cmp::Ordering;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(super) struct Depth(u8, Option<u8>);
+
+impl Depth {
+    #[inline]
+    pub(super) fn new(min: u8, max: u8) -> Self {
+        debug_assert!(min <= max);
+        Self(max, (min < max).then_some(min))
+    }
+}
+
+impl PartialEq<(u8, Option<u8>)> for Depth {
+    #[inline]
+    fn eq(&self, other: &(u8, Option<u8>)) -> bool {
+        (self.0, self.1).eq(other)
+    }
+}
+
+impl PartialOrd for Depth {
+    #[inline]
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.0.cmp(&other.0).then_with(|| match (self.1, other.1) {
+            (Some(ref l), Some(ref r)) => l.cmp(r),
+            (None, Some(_)) => Ordering::Greater,
+            (Some(_), None) => Ordering::Less,
+            (None, None) => Ordering::Equal,
+        }))
+    }
+}
+
+impl From<u8> for Depth {
+    #[inline]
+    fn from(depth: u8) -> Self {
+        Self(depth, None)
+    }
+}
+
+impl From<Depth> for (u8, Option<u8>) {
+    #[inline]
+    fn from(depth: Depth) -> Self {
+        (depth.0, depth.1)
+    }
+}

--- a/hashtree/src/hash/mod.rs
+++ b/hashtree/src/hash/mod.rs
@@ -138,7 +138,7 @@ impl<H: Hasher> HashNode<H> {
     /// Return the min. depth of this node's subtree, computed recursively.
     ///
     /// Note: min. depth is always right-handed.
-    fn min_depth(&self) -> usize {
+    fn min_depth(&self) -> u8 {
         match self {
             Self::Leaf(_) => 0,
             Self::Branch(_, nodes) | Self::Frozen(_, nodes) => 1 + nodes.1.min_depth(),
@@ -148,7 +148,7 @@ impl<H: Hasher> HashNode<H> {
     /// Return the max. depth of this node's subtree, computed recursively.
     ///
     /// Note: max. depth is always left-handed.
-    fn max_depth(&self) -> usize {
+    fn max_depth(&self) -> u8 {
         match self {
             Self::Leaf(_) => 0,
             Self::Branch(_, nodes) | Self::Frozen(_, nodes) => 1 + nodes.0.max_depth(),
@@ -157,9 +157,9 @@ impl<H: Hasher> HashNode<H> {
 
     /// Convenient method to aggregate min. / max. depth as `(max, Some(min))`.
     ///
-    /// If the returned `Option<usize>` is `None`, it also means the subtree is full.
+    /// If the returned `Option<u8>` is `None`, it also means the subtree is full.
     #[allow(dead_code)]
-    fn depth(&self) -> (usize, Option<usize>) {
+    fn depth(&self) -> (u8, Option<u8>) {
         let min_depth = self.min_depth();
         let max_depth = self.max_depth();
 
@@ -271,7 +271,7 @@ impl<H: Hasher> HashNode<H> {
     ///
     /// It browses all the subtree in a left-handed way.
     fn visit_nodes(&self) -> impl Iterator<Item = &Self> {
-        let mut rights = Vec::with_capacity(self.max_depth());
+        let mut rights = Vec::with_capacity(self.max_depth().into());
 
         std::iter::successors(Some(self), move |&node| {
             if let Some((left, right)) = node.nodes() {
@@ -556,7 +556,7 @@ mod tests {
             assert_eq!(leaf_nodes, root.len()); // the length of a tree is its number of leaves
             assert_eq!(branch_nodes, root.len() - 1); // there is one branch less than leaves
 
-            assert_eq!(root.max_depth(), root.len().next_power_of_two().ilog2() as usize);
+            assert_eq!(root.max_depth() as u32, root.len().next_power_of_two().ilog2());
         }
     }
 

--- a/hashtree/src/hash/mod.rs
+++ b/hashtree/src/hash/mod.rs
@@ -72,12 +72,8 @@ impl<H: Hasher> TryFrom<(Self, Self)> for HashNode<H> {
             return Err(Error::RightNodeNotCompliant);
         }
 
-        let mut right_node = &right;
-        while let Some((left_subtree, right_subtree)) = right_node.nodes() {
-            if !left_subtree.is_full() {
-                return Err(Error::RightNodeNotCompliant);
-            }
-            right_node = right_subtree;
+        if !right.visit_right().flat_map(Self::nodes).all(|(left, _)| left.is_full()) {
+            return Err(Error::RightNodeNotCompliant);
         }
 
         Self::branch(left, right).ok_or(Error::NoHash)
@@ -247,7 +243,6 @@ impl<H: Hasher> HashNode<H> {
     }
 
     /// A convenient iterator to visit only right child nodes.
-    #[allow(dead_code)]
     fn visit_right(&self) -> impl Iterator<Item = &Self> {
         std::iter::successors(Some(self), |&node| node.nodes().map(|(_, right)| right))
     }

--- a/hashtree/src/hash/mod.rs
+++ b/hashtree/src/hash/mod.rs
@@ -1,3 +1,6 @@
+mod context;
+use context::Depth;
+
 mod proof;
 pub use proof::HashProof;
 
@@ -159,11 +162,11 @@ impl<H: Hasher> HashNode<H> {
     ///
     /// If the returned `Option<u8>` is `None`, it also means the subtree is full.
     #[allow(dead_code)]
-    fn depth(&self) -> (u8, Option<u8>) {
+    fn depth(&self) -> Depth {
         let min_depth = self.min_depth();
         let max_depth = self.max_depth();
 
-        (max_depth, (min_depth != max_depth).then_some(min_depth))
+        Depth::new(min_depth, max_depth)
     }
 
     /// Return the length of this node's subtree, computed recursively.

--- a/hashtree/src/hash/mod.rs
+++ b/hashtree/src/hash/mod.rs
@@ -224,7 +224,7 @@ impl<H: Hasher> HashNode<H> {
         match self {
             Self::Leaf(None) => Self::leaf(other),
             leaf @ Self::Leaf(Some(_)) => Self::branch(leaf, Self::leaf(other)).unwrap(),
-            branch @ Self::Branch(_, _) => {
+            branch @ Self::Branch(..) => {
                 if branch.is_full() {
                     Self::branch(branch, Self::leaf(other)).unwrap()
                 } else {
@@ -441,9 +441,9 @@ mod tests {
         node.push("");
         assert_matches!(&node, HashNode::Branch(_, n) if matches!(**n, (HashNode::Leaf(Some(_)), HashNode::Leaf(Some(_)))));
         node.push("");
-        assert_matches!(&node, HashNode::Branch(_, n) if matches!(**n, (HashNode::Branch(_, _), HashNode::Leaf(Some(_)))));
+        assert_matches!(&node, HashNode::Branch(_, n) if matches!(**n, (HashNode::Branch(..), HashNode::Leaf(Some(_)))));
         node.push("");
-        assert_matches!(&node, HashNode::Branch(_, n) if matches!(**n, (HashNode::Branch(_, _), HashNode::Branch(_, _))));
+        assert_matches!(&node, HashNode::Branch(_, n) if matches!(**n, (HashNode::Branch(..), HashNode::Branch(..))));
     }
 
     #[test]

--- a/hashtree/src/hash/mod.rs
+++ b/hashtree/src/hash/mod.rs
@@ -1,5 +1,3 @@
-use std::fmt::Debug;
-
 mod proof;
 pub use proof::HashProof;
 
@@ -14,7 +12,7 @@ enum Error {
 /// A hasher trait to produce hash values.
 pub trait Hasher: Default {
     /// Type associated to this `Hasher` implemention.
-    type Hash: AsRef<[u8]> + PartialEq + Debug;
+    type Hash: AsRef<[u8]> + PartialEq + std::fmt::Debug;
 
     /// Feed the hasher with a new value to be hashed.
     fn write(&mut self, bytes: &[u8]);
@@ -48,7 +46,6 @@ pub trait Hasher: Default {
 ///
 /// A hash node is made to grow in a way that left subtrees of its recursive right nodes are always fully balanced.
 /// Its implementation tries to make the most of this assertion.
-#[derive(Debug)]
 enum HashNode<H: Hasher> {
     Branch(H::Hash, Box<(HashNode<H>, HashNode<H>)>),
     Leaf(Option<H::Hash>),
@@ -57,6 +54,16 @@ enum HashNode<H: Hasher> {
 impl<H: Hasher> Default for HashNode<H> {
     fn default() -> Self {
         Self::Leaf(None)
+    }
+}
+
+// Don't use `#[derive(Debug)]` here as it would require `Hasher` to implement `Debug` as well.
+impl<H: Hasher> std::fmt::Debug for HashNode<H> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Leaf(opt) => write!(f, "Leaf({opt:?})"),
+            Self::Branch(hash, nodes) => write!(f, "Branch({hash:?}, {nodes:?})"),
+        }
     }
 }
 

--- a/hashtree/src/hash/proof.rs
+++ b/hashtree/src/hash/proof.rs
@@ -42,17 +42,17 @@ pub struct HashProof<'p, H: Hasher> {
 impl<'h, H: Hasher> HashProof<'h, H> {
     /// Build a hash proof from all sibling hashes required to compute the root hash for a given leaf hash value.
     pub(super) fn new(mut path: Vec<&'h HashNode<H>>) -> Self {
-        let mut root = path.pop().and_then(HashNode::hash);
+        let mut root = path.pop().map(HashNode::hash);
         let mut hashes = Vec::with_capacity(path.len());
 
         while let Some(node) = path.pop() {
             match node.nodes() {
-                Some((left, right)) if left.hash() == root => hashes.push(Hash::Right(right.hash().unwrap())),
-                Some((left, right)) if right.hash() == root => hashes.push(Hash::Left(left.hash().unwrap())),
+                Some((left, right)) if Some(left.hash()) == root => hashes.push(Hash::Right(right.hash())),
+                Some((left, right)) if Some(right.hash()) == root => hashes.push(Hash::Left(left.hash())),
                 _ => unreachable!(),
             }
 
-            root = node.hash()
+            root = Some(node.hash())
         }
 
         Self { root, hashes }

--- a/hashtree/src/hash/proof.rs
+++ b/hashtree/src/hash/proof.rs
@@ -1,5 +1,3 @@
-use std::fmt::Debug;
-
 use super::{HashNode, Hasher};
 
 /// A single hash in a hash tree.


### PR DESCRIPTION
Some refactors to address those issues:
- Limit recursive calls when computing the depth and the length of a tree.
- Try to reduce `Option` and `Option::unwrap()` usage in `HashNode` handling.
